### PR TITLE
bugfix: you need default lang to define _

### DIFF
--- a/kombilo/kombilo.py
+++ b/kombilo/kombilo.py
@@ -3245,10 +3245,10 @@ class App(v.Viewer, KEngine):
                 pass
 
     def switch_language(self, lang, show_warning=False):
+        v.Viewer.switch_language(self, lang, show_warning)
+
         self.options.continuations_sort_crit.set(self.untranslate_cont_sort_crit())
         self.options.tagAsPro.set(self.untranslate_tagAsPro())
-
-        v.Viewer.switch_language(self, lang, show_warning)
 
         for var in [self.options.continuations_sort_crit, self.options.tagAsPro, ]:
             var.set(_(var.get()))
@@ -3709,4 +3709,3 @@ def run():
 
 if __name__ == '__main__':
     run()
-

--- a/kombilo/v.py
+++ b/kombilo/v.py
@@ -2843,6 +2843,8 @@ class Viewer:
 
         if self.options.language.get():
             self.switch_language(self.options.language.get())
+        else:
+            self.switch_language('en')
 
         if self.options.scaling.get() == -1:
             # Application is opened for the first time, so we adjust button size
@@ -3025,4 +3027,3 @@ def run():
 
 if __name__ == '__main__':
     run()
-


### PR DESCRIPTION
I might finally understand the issue #2 .

If there are no options for language, Viewer misses calling switch_language, that causes no definitions of the function _.

I added codes to call switch_language('en') as default language, and changed the order of lines in swtich_language in kombilo since untranslate_cont_sort_crit uses the function _.