### PR TITLE
Specify c++14 standard.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ elif sys.platform.startswith('darwin'):
 else:
     kwargs['libraries'] = ['stdc++', 'sqlite3']
     kwargs['library_dirs'] = ['/usr/lib', ]
-    kwargs['extra_compile_args'] = ['-O3', '-I.', '-fopenmp']  # can use this w/ g++ to max optimization
+    kwargs['extra_compile_args'] = ['-O3', '-I.', '-fopenmp', "-std=c++14"]  # can use this w/ g++ to max optimization
     kwargs['extra_link_args'] = [ '-lgomp', ]
 
 kwargs['sources'] = sources


### PR DESCRIPTION
Modern gcc defaults to C++17, and this leads to some build errors (C++17 removed dynamic exception specifications). Specifying C++14 as the standard fixes these.